### PR TITLE
Update app.yaml

### DIFF
--- a/compose/app.yaml
+++ b/compose/app.yaml
@@ -18,6 +18,7 @@ services:
     env_file:
       - ../config/peatio/application.env
     environment:
+      PORT: 8000
       DATABASE_USER: root
       DATABASE_PASS: changeme
     volumes:


### PR DESCRIPTION
Peatio could not start on 8000 since port setting was missing.
Also mentioned in: https://github.com/rubykube/peatio/issues/934
P.S: Already fixed in master but missing in 1-6-stable