### PR TITLE
Makefile: adding a bit more resilency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ dependencies:
 prepare: dependencies daemons cryptonodes
 
 setup-apps: build
-	$(COMPOSE) run --rm peatio bash -c "./bin/link_config && rake db:create db:migrate db:seed"
+	$(COMPOSE) run --rm peatio bash -c "./bin/link_config && bundle exec rake db:create db:migrate db:seed"
 	$(COMPOSE) run --rm barong bash -c "./bin/link_config && ./bin/setup"
 
 run: prepare setup-apps


### PR DESCRIPTION
Sometimes there could be a mismatch in `rake` version used by docker image and one provided in Gemfile. This small little change will insure that correct version of rake is used at all times.

This should hopefully avoid some errors during builds (I've ran into one myself)