### PR TITLE
Replace dead smtp_relay by mailcather

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,17 @@ COMPOSE = docker-compose
 default: run
 
 build:
-	$(COMPOSE) build peatio     \
-	                 barong     \
-	                 trading_ui \
-	                 vault      \
-	                 db         \
-	                 phpmyadmin \
-	                 redis      \
-	                 rabbitmq   \
-	                 smtp_relay \
-	                 slanger    \
-	                 coinhub    \
+	$(COMPOSE) build peatio      \
+	                 barong      \
+	                 trading_ui  \
+	                 vault       \
+	                 db          \
+	                 phpmyadmin  \
+	                 redis       \
+	                 rabbitmq    \
+	                 mailcatcher \
+	                 slanger     \
+	                 coinhub     \
 	                 integration
 
 geth:
@@ -44,7 +44,7 @@ daemons:
 	                         withdraw_coin
 
 dependencies:
-	$(COMPOSE) up -d vault db phpmyadmin redis rabbitmq smtp_relay slanger coinhub
+	$(COMPOSE) up -d vault db phpmyadmin redis rabbitmq mailcatcher slanger coinhub
 	$(COMPOSE) run --rm vault secrets enable totp || true
 
 prepare: dependencies daemons cryptonodes

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ You should add those hosts to your `/etc/hosts` file:
 
 0.0.0.0 btc.wb.local
 0.0.0.0 eth.wb.local
+
+0.0.0.0 mail.wb.local
 ```
 
 Now you have peatio up and running.

--- a/compose/app.yaml
+++ b/compose/app.yaml
@@ -9,7 +9,6 @@ services:
       - db
       - redis
       - rabbitmq
-      - smtp_relay
       - barong
       - slanger
       - geth
@@ -33,6 +32,7 @@ services:
       - proxy
       - db
       - vault
+      - mailcatcher
     env_file:
       - ../config/barong.env
     volumes:

--- a/compose/backend.yaml
+++ b/compose/backend.yaml
@@ -1,11 +1,6 @@
 version: '3.6'
 
 services:
-  smtp_relay:
-    image: kaigara/postfix:latest
-    volumes:
-      - ../config/smtp-relay.yaml:/etc/kaigara/metadata/relay.yml
-
   db:
     image: mysql:5.7
     volumes:
@@ -71,6 +66,13 @@ services:
       traefik.ws.port: 8080
       traefik.api.frontend.rule: 'Host: api.slanger.wb.local'
       traefik.api.port: 4567
+
+  mailcatcher:
+    image: schickling/mailcatcher
+    labels:
+      traefik.enable: true
+      traefik.frontend.rule: 'Host: mail.wb.local'
+      traefik.port: 1080
 
 volumes:
   db_data:

--- a/compose/daemons.yaml
+++ b/compose/daemons.yaml
@@ -10,7 +10,6 @@ x-daemon: &peatio-daemon
     - redis
     - rabbitmq
     - geth
-    - smtp_relay
     - barong
     - slanger
     - coinhub

--- a/config/barong.env
+++ b/config/barong.env
@@ -4,6 +4,9 @@ LOG_LEVEL=debug
 
 RAILS_ENV=development
 
+SMTP_ADDRESS=mailcatcher
+SMTP_PORT=1025
+
 DATABASE_HOST=db
 DATABASE_USER=root
 DATABASE_PASSWORD=changeme

--- a/config/smtp-relay.yaml
+++ b/config/smtp-relay.yaml
@@ -1,8 +1,0 @@
----
-hostname: "relay"
-fqdn: "helioscloud.com"
-defaultUser: "kayen"
-relayHost: "[smtp.sendgrid.net]:2525"
-sendgrid:
-  username: "apikey"
-  password: "*********************************************************************"


### PR DESCRIPTION
Closes #155.
Closes #156.

- Remove outdated `smtp_relay`.
- Add `mailcather` (Now it is available in rubykube/barong#573).
- Make `mailcatcher` accessible from network (as `mail.wb.local`).