### PR TITLE
Add stronger password for admin@barong.io

### DIFF
--- a/config/barong/seeds.yml
+++ b/config/barong/seeds.yml
@@ -8,7 +8,7 @@
 accounts:
   - account:
       email: admin@barong.io
-      password: "Qwerty123"
+      password: "Chah5YohWm"
       role: admin
       state: active
       level: 3

--- a/config/integration/fixtures/user.json
+++ b/config/integration/fixtures/user.json
@@ -1,4 +1,4 @@
 {
 	"login": "admin@barong.io",
-	"password": "Qwerty123"
+	"password": "Chah5YohWm"
 }


### PR DESCRIPTION
Add a stronger password for seeded user admin@barong.io, due to Barong's new password validation