### PR TITLE
fix for make run error

### DIFF
--- a/config/peatio-seed-btc/currencies.yml
+++ b/config/peatio-seed-btc/currencies.yml
@@ -4,7 +4,6 @@
   precision:            8
   base_factor:          1
   enabled:              true
-  quick_withdraw_limit: 1000
   deposit_fee:          0
   withdraw_fee:         0
   min_deposit_amount:   0


### PR DESCRIPTION
while deploying workbench, the `make run` command was giving an error and saying "unknown attribute quck_withdraw_limit for Currency" and deleting that line of code seems to be a fix for that problem. However the workbench is pulling 1.9.1 rc.22, so if the attribute is added in the later versions, updating the pulled release could also fix the problem.