### PR TITLE
ERROR: for peatio-workbench_peatio_daemons_1  Cannot start service peatio_daemons: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"god\": executable file not found in $PATH": unknown

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
     build:
       context: peatio
       dockerfile: Dockerfile
-    restart: always
     depends_on:
       - db
       - redis
@@ -22,6 +21,14 @@ services:
       - RABBITMQ_HOST=rabbitmq
     volumes:
       - ./peatio:/home/app
+    entrypoint:
+      - /bin/sh
+      - -xc
+    command:
+      - |
+        ./bin/init_config
+        bundle exec rake db:create db:migrate db:seed
+        bundle exec puma --config config/puma.rb
 
   peatio_daemons:
     build:


### PR DESCRIPTION
after run $ make prepare i got this error
![Screenshot from 2019-07-07 20-21-53](https://user-images.githubusercontent.com/1058663/60769698-e40c8180-a0f4-11e9-97ae-4b0c98044d9e.png)




ERROR: for peatio-workbench_peatio_daemons_1  Cannot start service peatio_daemons: OCI runtime create failed: container_linux.go:345: starting container process caused "exec: \"god\": executable file not found in $PATH": unknown


